### PR TITLE
DRIFT-510: Make package paths by using time from InfluxDB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+
+## Changed:
+
+- DRIFT-510: Make package paths by using time from InfluxDB, [PR-2](https://github.com/panda-official/DriftPythonClient/pull/2)
+
 ## [0.1.1] - 2022-07-12
 
 ## Added

--- a/examples/get_list.py
+++ b/examples/get_list.py
@@ -11,15 +11,15 @@ logging.basicConfig(level=logging.INFO)
 
 def main():
     # Init
-    drift_client = DriftClient("10.0.0.153", os.getenv("DRIFT_PASSWORD"))
+    drift_client = DriftClient("drift-test-rig.local", os.getenv("DRIFT_PASSWORD"))
     # Download list of history
     packages = drift_client.get_list(
-        ["acc-5"],
+        ["acc-1"],
         [
-            (datetime.datetime.now() - datetime.timedelta(minutes=2)).strftime(
+            (datetime.datetime.utcnow() - datetime.timedelta(minutes=2)).strftime(
                 "%Y-%m-%d %H:%M:%S"
             ),
-            (datetime.datetime.now() - datetime.timedelta(minutes=1)).strftime(
+            (datetime.datetime.utcnow() - datetime.timedelta(minutes=1)).strftime(
                 "%Y-%m-%d %H:%M:%S"
             ),
         ],

--- a/pkg/drift_client/drift_client.py
+++ b/pkg/drift_client/drift_client.py
@@ -107,7 +107,7 @@ class DriftClient:
 
             data[topic] = []
 
-            for timestamp, value in to_request:
+            for timestamp, _ in to_request:
                 data[topic].append(f"{topic}/{int(timestamp * 1000)}.dp")
 
         return data

--- a/pkg/drift_client/drift_client.py
+++ b/pkg/drift_client/drift_client.py
@@ -96,18 +96,19 @@ class DriftClient:
             >>> # => {"topic-1": ['topic-1/1644750600291.dp',
             >>> #                  'topic-1/1644750601291.dp', ...] ... }
         """
-        to_request = self.__influx_client.query_data(topics, timeframe[0], timeframe[1])
-
         data = {}
-
-        if not to_request:
-            return data
-
         for topic in topics:
+            to_request = self.__influx_client.query_data(
+                topic, timeframe[0], timeframe[1], field="status"
+            )
+
+            if not to_request:
+                break
+
             data[topic] = []
 
-        for file in to_request:
-            data[file.split("/")[0]].append(file)
+            for timestamp, value in to_request:
+                data[topic].append(f"{topic}/{int(timestamp * 1000)}.dp")
 
         return data
 

--- a/pkg/drift_client/drift_client.py
+++ b/pkg/drift_client/drift_client.py
@@ -105,6 +105,7 @@ class DriftClient:
             if not influxdb_values:
                 break
 
+            data[topic] = []
             for timestamp, _ in influxdb_values:
                 data[topic].append(f"{topic}/{int(timestamp * 1000)}.dp")
 

--- a/pkg/drift_client/drift_client.py
+++ b/pkg/drift_client/drift_client.py
@@ -98,16 +98,14 @@ class DriftClient:
         """
         data = {}
         for topic in topics:
-            to_request = self.__influx_client.query_data(
+            influxdb_values = self.__influx_client.query_data(
                 topic, timeframe[0], timeframe[1], field="status"
             )
 
-            if not to_request:
+            if not influxdb_values:
                 break
 
-            data[topic] = []
-
-            for timestamp, _ in to_request:
+            for timestamp, _ in influxdb_values:
                 data[topic].append(f"{topic}/{int(timestamp * 1000)}.dp")
 
         return data

--- a/pkg/drift_client/influxdb_client.py
+++ b/pkg/drift_client/influxdb_client.py
@@ -3,8 +3,8 @@
 
 from typing import List, Tuple, Any
 from datetime import datetime
-
 from urllib.parse import urlparse
+
 from influxdb_client import InfluxDBClient as Client
 
 
@@ -68,7 +68,7 @@ class InfluxDBClient:
         start: str,
         stop: str,
         field: str = "src",
-    ) -> List[Tuple[float, str]]:
+    ) -> List[Tuple[float, Any]]:
         """InfluxDB queries for values"""
         # Change time format for request
         start = datetime.strptime(start, self.__input_time_fmt).strftime(

--- a/tests/drift_client_test.py
+++ b/tests/drift_client_test.py
@@ -13,6 +13,13 @@ def _mock_influx_class(mocker):
     return mocker.patch("drift_client.drift_client.InfluxDBClient")
 
 
+@pytest.fixture(name="influxdb_client")
+def _mock_influx_client(mocker, influxdb_klass):
+    client = mocker.Mock()
+    influxdb_klass.return_value = client
+    return client
+
+
 def test__default_initialization(minio_klass, influxdb_klass):
     """should initialize clients with default settings"""
     _ = DriftClient("host_name", "password")
@@ -20,4 +27,18 @@ def test__default_initialization(minio_klass, influxdb_klass):
     minio_klass.assert_called_with("http://host_name:9000", "panda", "password", False)
     influxdb_klass.assert_called_with(
         "http://host_name:8086", "panda", "password", False
+    )
+
+
+@pytest.mark.usefixtures("minio_klass")
+def test__timestamp_from_influxdb(influxdb_client):
+    """should get timestamp and values for records from influxdb and make paths in minio"""
+    client = DriftClient("host_name", "password")
+    influxdb_client.query_data.return_value = [(10000.0, 100), (10010.0, 200)]
+
+    data = client.get_list(["topic"], ["2022-01-01 00:00:00", "2022-01-01 00:00:00"])
+    assert data == {"topic": ["topic/10000000.dp", "topic/10010000.dp"]}
+
+    influxdb_client.query_data.assert_called_with(
+        "topic", "2022-01-01 00:00:00", "2022-01-01 00:00:00", field="status"
     )

--- a/tests/drift_client_test.py
+++ b/tests/drift_client_test.py
@@ -32,9 +32,10 @@ def test__default_initialization(minio_klass, influxdb_klass):
 
 @pytest.mark.usefixtures("minio_klass")
 def test__timestamp_from_influxdb(influxdb_client):
-    """should get timestamp and values for records from influxdb and make paths in minio"""
+    """should get timestamp and values for records
+    from influxdb and make paths in minio"""
     client = DriftClient("host_name", "password")
-    influxdb_client.query_data.return_value = [(10000.0, 100), (10010.0, 200)]
+    influxdb_client.query_data.return_value = [(10000.0, 0), (10010.0, 512)]
 
     data = client.get_list(["topic"], ["2022-01-01 00:00:00", "2022-01-01 00:00:00"])
     assert data == {"topic": ["topic/10000000.dp", "topic/10010000.dp"]}


### PR DESCRIPTION
**Closes** DRIFT-510

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Change

### What is the current behavior?

Currently, we get paths of objects in Minio from InfluxDb. We have to store the paths as string in `src` field that takes disk space.

### What is the new behavior?

This path uses the name convention and the timestamps of records in Influxdb. It is not necessary to store the paths anymore. 

### Does this PR introduce a breaking change?** 

Nope
