### PR TITLE
Add S3 error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added:
+
+- DRIFT-550: DriftClientError class, to catch (initially) Minio errors, [PR-16](https://github.com/panda-official/DriftPythonClient/pull/16)
+
 ## 0.2.1 - 2922-09-09
 
 ### Added:

--- a/pkg/drift_client/error.py
+++ b/pkg/drift_client/error.py
@@ -3,5 +3,3 @@
 
 class DriftClientError(Exception):
     """A preliminary generic error"""
-
-    pass

--- a/pkg/drift_client/error.py
+++ b/pkg/drift_client/error.py
@@ -1,0 +1,7 @@
+"""DriftClient Errors"""
+
+
+class DriftClientError(Exception):
+    """A preliminary generic error"""
+
+    pass

--- a/pkg/drift_client/minio_client.py
+++ b/pkg/drift_client/minio_client.py
@@ -5,6 +5,9 @@ from typing import Optional
 
 from urllib.parse import urlparse
 from minio import Minio
+from minio.error import S3Error
+
+from .error import DriftClientError
 
 
 class MinIOClient:
@@ -54,6 +57,8 @@ class MinIOClient:
         try:
             response = self.__client.get_object(self.__bucket, path)
             data = response.read()
+        except S3Error as err:
+            raise DriftClientError(err)
         finally:
             if response:
                 response.close()

--- a/pkg/drift_client/minio_client.py
+++ b/pkg/drift_client/minio_client.py
@@ -58,7 +58,7 @@ class MinIOClient:
             response = self.__client.get_object(self.__bucket, path)
             data = response.read()
         except S3Error as err:
-            raise DriftClientError(err)
+            raise DriftClientError("Could not read item at %s", path) from err
         finally:
             if response:
                 response.close()

--- a/pkg/drift_client/minio_client.py
+++ b/pkg/drift_client/minio_client.py
@@ -58,7 +58,7 @@ class MinIOClient:
             response = self.__client.get_object(self.__bucket, path)
             data = response.read()
         except S3Error as err:
-            raise DriftClientError("Could not read item at %s", path) from err
+            raise DriftClientError(f"Could not read item at {path}") from err
         finally:
             if response:
                 response.close()

--- a/tests/minio_client_test.py
+++ b/tests/minio_client_test.py
@@ -1,0 +1,34 @@
+"""Minio Client"""
+import pytest
+
+from minio.error import S3Error
+from drift_client.minio_client import MinIOClient
+from drift_client.error import DriftClientError
+
+
+@pytest.fixture(name="minio_client")
+def _make_minio_client(mocker):
+    """fake client which just raises an S3error"""
+    client_klass = mocker.patch("drift_client.minio_client.Minio")
+    client = mocker.Mock()
+    client.get_object = mocker.Mock(
+        side_effect=S3Error(
+            code="someErrorCode",
+            message="Something Went Wrong",
+            resource="data",
+            request_id="8BADF00D",
+            host_id="DEADBEEF",
+            response=None,
+        )
+    )
+    client_klass.return_value = client
+
+    return client_klass
+
+
+def test__rasise_drift_error(minio_client):
+    """make sure client raises correct error"""
+    test_path = "non_existant_data.ext"
+    client = MinIOClient("localhost:9000", "user", "password", secure=False)
+    with pytest.raises(DriftClientError, match=f"Could not read item at {test_path}"):
+        client.fetch_data(test_path)

--- a/tests/minio_client_test.py
+++ b/tests/minio_client_test.py
@@ -6,7 +6,7 @@ from drift_client.minio_client import MinIOClient
 from drift_client.error import DriftClientError
 
 
-@pytest.fixture(name="minio_client")
+@pytest.fixture(name="_minio_client")
 def _make_minio_client(mocker):
     """fake client which just raises an S3error"""
     client_klass = mocker.patch("drift_client.minio_client.Minio")
@@ -26,8 +26,9 @@ def _make_minio_client(mocker):
     return client_klass
 
 
-def test__rasise_drift_error(minio_client):
+def test__rasise_drift_error(_minio_client):
     """make sure client raises correct error"""
+
     test_path = "non_existant_data.ext"
     client = MinIOClient("localhost:9000", "user", "password", secure=False)
     with pytest.raises(DriftClientError, match=f"Could not read item at {test_path}"):


### PR DESCRIPTION
**Closes** #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Add feature to abstract `Minio.S3Errors` away from the user.

### What is the current behavior?

Raise a Minio error when data not found.

### What is the new behavior?

Raise a `DriftClientError`.


### Does this PR introduce a breaking change?

No

### Other information:
