### PR TITLE
DRIFT-603: Fix check status for DriftDataPackage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - DRIFT-550: DriftClientError class, to catch (initially) Minio errors, [PR-16](https://github.com/panda-official/DriftPythonClient/pull/16)
 - DRIFT-604: Add blob property to DriftDataPackage, [PR-20](https://github.com/panda-official/DriftPythonClient/pull/20)
 
+### Fixed:
+
+- DRIFT-603: Status check for DriftDataPackage, [PR-23](https://github.com/panda-official/DriftPythonClient/pull/23)
+
 ## 0.2.1 - 2922-09-09
 
 ### Added:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - DRIFT-545: Build on Apple M1, [PR-15](https://github.com/panda-official/DriftPythonClient/pull/15)
 
-
 ## 0.2.0 - 2022-08-16
 
 ### Added:

--- a/pkg/drift_client/drift_data_package.py
+++ b/pkg/drift_client/drift_data_package.py
@@ -10,10 +10,10 @@ import numpy as np
 def check_status(func):
     """Check Package status"""
 
-    def dec(self):
+    def dec(self, **kwargs):
         if self._pkg.status != StatusCode.GOOD:  # pylint: disable=protected-access
             raise ValueError("Bad package")
-        return func(self)
+        return func(self, **kwargs)
 
     return dec
 

--- a/tests/package_test.py
+++ b/tests/package_test.py
@@ -65,3 +65,9 @@ def test__package_parsing(good_package, buffer, signal):
     assert pkg.as_buffer() == buffer
     assert list(pkg.as_np()) == list(signal)
     assert pkg.blob == good_package.SerializeToString()
+
+
+def test__scale_factor(good_package, signal):
+    """Should return scaled data"""
+    pkg = DriftDataPackage(good_package.SerializeToString())
+    assert len(pkg.as_np(scale_factor=1)) == int(len(signal) / 2)


### PR DESCRIPTION
**Closes** #18 

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Bug fix

### What is the current behavior?

To check a status of a package, we use a decorator, which didn't work with functions with parameters. 

### What is the new behavior?

Fixed the decorator


### Does this PR introduce a breaking change?

No

### Other information:
