### PR TITLE
check password and fix error message when no reductstore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed:
+
+- Empty password and error message when no ReductStore available, [PR-30](https://github.com/panda-official/DriftPythonClient/pull/30)
+
 ### 0.4.0 - 2023-02-13
 
 ### Added:

--- a/examples/get_item.py
+++ b/examples/get_item.py
@@ -11,7 +11,7 @@ logging.basicConfig(level=logging.INFO)
 
 def main():
     # Init
-    drift_client = DriftClient("10.0.0.153", os.getenv("DRIFT_PASSWORD"))
+    drift_client = DriftClient("10.66.35.23", os.getenv("DRIFT_PASSWORD"))
 
     # Download single package
     package = drift_client.get_item("acc-5/1648457411593.dp")

--- a/tests/drift_client_test.py
+++ b/tests/drift_client_test.py
@@ -46,7 +46,7 @@ def test__default_initialization(influxdb_klass, reduct_klass):
     )
 
 
-def test__minio_password_required(minio_klass, reduct_klass):
+def test__minio_password_required():
     """should raise error if no password is not provided"""
     with pytest.raises(ValueError):
         _ = DriftClient("host_name", None)

--- a/tests/drift_client_test.py
+++ b/tests/drift_client_test.py
@@ -2,6 +2,7 @@
 from datetime import datetime
 
 import pytest
+from reduct import ReductError
 
 from drift_client import DriftClient
 
@@ -45,10 +46,16 @@ def test__default_initialization(influxdb_klass, reduct_klass):
     )
 
 
+def test__minio_password_required(minio_klass, reduct_klass):
+    """should raise error if no password is not provided"""
+    with pytest.raises(ValueError):
+        _ = DriftClient("host_name", None)
+
+
 @pytest.mark.usefixtures("minio_klass")
 def test__minio_fallback(reduct_klass, minio_klass):
-    """should initialize minio client if reduct storage is not available"""
-    reduct_klass.side_effect = Exception("Boom")
+    """should initialize minio client if ReductStore is not available"""
+    reduct_klass.side_effect = ReductError(599, "Connection error")
 
     _ = DriftClient("host_name", "password")
     minio_klass.assert_called_with("http://host_name:9000", "panda", "password", False)


### PR DESCRIPTION
**Closes** #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Bug fix

### What is the current behavior?

When ReductStore is not available, the client tries to use Minio. If it's not possible as well e.g. the password is wrong, a user sees a confusing message from ReductStore. 

### What is the new behavior?

First of all, check empty password. Then don't try to connect to Minio in try-exept during handling an error from ReductStore.


### Does this PR introduce a breaking change?

No

### Other information:
