### PR TITLE
Switch to wavelet buffer 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- Switch to wavelet buffer 0.6.0, [PR-31](https://github.com/panda-official/DriftPythonClient/pull/31)
+
 ## 0.4.1 - 2023-02-21
 
 ### Fixed:

--- a/setup.py
+++ b/setup.py
@@ -7,8 +7,8 @@ from setuptools import setup, find_packages
 
 PACKAGE_NAME = "drift-python-client"
 MAJOR_VERSION = 0
-MINOR_VERSION = 4
-PATCH_VERSION = 1
+MINOR_VERSION = 5
+PATCH_VERSION = 0
 VERSION_SUFFIX = os.getenv("VERSION_SUFFIX")
 
 HERE = Path(__file__).parent.resolve()
@@ -52,7 +52,7 @@ setup(
     install_requires=[
         "influxdb-client==1.30.0",
         "drift-protocol>=0.3.0, <1.0",
-        "wavelet-buffer>=0.4.0, <1.0",
+        "wavelet-buffer>=0.6.0, <1.0",
         "paho-mqtt==1.6.1",
         "numpy==1.23.1",
         "deprecation==2.1.0",


### PR DESCRIPTION
**Closes** #

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Update

### What is the current behavior?

The minimal version of WaveletBuffer is 0.4. However, we enabled a new compression algorithm in 0.6.0. So we need to switch to the latest version.

### What is the new behavior?

Minimal version of WaveletBuffer is 0.6.0


### Does this PR introduce a breaking change?

(What changes might users need to make in their application due to this PR?)

### Other information:
