### PR TITLE
DRIFT-613: Implement `Client.walk` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added:
+
+- DRIFT-613: `Client.walk` method to iterate data in blob storage, [PR-32](https://github.com/panda-official/DriftPythonClient/pull/32)
+
 ## 0.5.0 - 2023-04-06
 
 ### Changed

--- a/examples/get_package_names.py
+++ b/examples/get_package_names.py
@@ -1,11 +1,9 @@
+import datetime
+import logging
 import os
-from datetime import timezone
+import sys
 
 from drift_client import DriftClient
-
-import logging
-import sys
-import datetime
 
 logging.basicConfig(level=logging.INFO)
 

--- a/examples/walk_topic.py
+++ b/examples/walk_topic.py
@@ -1,0 +1,27 @@
+import os
+
+from drift_client import DriftClient
+
+import logging
+import sys
+
+logging.basicConfig(level=logging.DEBUG)
+
+
+def main():
+    # Timeseries example
+
+    # Init
+    drift_client = DriftClient("drift-dev2.local", os.getenv("DRIFT_PASSWORD"))
+
+    # Download historic data
+    topics = drift_client.get_topics()
+    # Show list of topics
+    print(topics)
+    # Download data for topic
+    for pkg in drift_client.walk("acc-6", "2023-06-16T10:00", "2023-06-16T10:10"):
+        print(pkg)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pkg/drift_client/drift_client.py
+++ b/pkg/drift_client/drift_client.py
@@ -233,7 +233,8 @@ class DriftClient:
 
         Examples:
             >>> client = DriftClient("127.0.0.1", "PASSWORD")
-            >>> for pkg in  client.walk("topic-1", "2022-02-03 10:00:00", "2022-02-03 10:00:10")
+            >>> for pkg in  client.walk("topic-1", "2022-02-03 10:00:00",
+                "2022-02-03 10:00:10")
             >>>     print(pkg)
         """
 

--- a/pkg/drift_client/minio_client.py
+++ b/pkg/drift_client/minio_client.py
@@ -70,3 +70,6 @@ class MinIOClient:
                 response.release_conn()
 
         return data
+
+    def name(self):
+        return "minio"

--- a/pkg/drift_client/minio_client.py
+++ b/pkg/drift_client/minio_client.py
@@ -72,4 +72,5 @@ class MinIOClient:
         return data
 
     def name(self):
+        """Return name of client"""
         return "minio"

--- a/pkg/drift_client/reduct_client.py
+++ b/pkg/drift_client/reduct_client.py
@@ -1,10 +1,11 @@
 """Reduct Storage client"""
 import asyncio
-from typing import Tuple, List, Optional, Dict, Iterator, AsyncIterator
 from asyncio import new_event_loop
+from typing import Tuple, List, Optional, Dict, Iterator
+
+from reduct import Client, Bucket, ReductError, EntryInfo
 
 from drift_client.error import DriftClientError
-from reduct import Client, Bucket, ReductError, EntryInfo
 
 
 class ReductStoreClient:
@@ -84,7 +85,7 @@ class ReductStoreClient:
 
         async def get_next():
             try:
-                pkg = await ait.__anext__()
+                pkg = await ait.__anext__()  # pylint: disable=unnecessary-dunder-call
                 return False, await pkg.read_all()
             except StopAsyncIteration:
                 return True, None
@@ -99,6 +100,7 @@ class ReductStoreClient:
             raise DriftClientError(f"Failed to fetch data: {err.message}") from err
 
     def name(self) -> str:
+        """Return name of the client"""
         return "reductstore"
 
     async def _read_by_timestamp(self, entry: str, timestamp: int) -> bytes:

--- a/tests/drift_client_test.py
+++ b/tests/drift_client_test.py
@@ -126,7 +126,7 @@ def test__walk_data(influxdb_client, reduct_client):
 
     reduct_client.walk.return_value = Iter([b"", b""])
 
-    data = [pkg for pkg in client.walk("topic", 0.0, 1.0)]
+    data = list(client.walk("topic", 0.0, 1.0))
     assert len(data) == 2
 
     influxdb_client.query_data.assert_not_called()

--- a/tests/drift_client_test.py
+++ b/tests/drift_client_test.py
@@ -1,10 +1,22 @@
 """Tests for DriftClient"""
 from datetime import datetime
+from typing import Optional, List, Any
 
 import pytest
 from reduct import ReductError
 
 from drift_client import DriftClient
+
+
+class Iter:  # pylint: disable=too-few-public-methods
+    """Helper class for efficient mocking"""
+
+    def __init__(self, items: Optional[List[Any]] = None):
+        self.items = items if items else []
+
+    def __iter__(self):
+        for item in self.items:
+            yield item
 
 
 @pytest.fixture(name="minio_klass")
@@ -106,6 +118,19 @@ def test__get_topic_data(influxdb_client, reduct_client, start_ts, stop_ts):
         "topic", 1640991600, 1640991600, fields="status"
     )
     reduct_client.check_package_list.assert_called_with(expected)
+
+
+def test__walk_data(influxdb_client, reduct_client):
+    """should iteratre data in reductstore and return it like a list of dictioniers"""
+    client = DriftClient("host_name", "password")
+
+    reduct_client.walk.return_value = Iter([b"", b""])
+
+    data = [pkg for pkg in client.walk("topic", 0.0, 1.0)]
+    assert len(data) == 2
+
+    influxdb_client.query_data.assert_not_called()
+    influxdb_client.walk.called_with("topic", 0, 1)
 
 
 @pytest.mark.usefixtures("reduct_klass")

--- a/tests/reduct_client_test.py
+++ b/tests/reduct_client_test.py
@@ -106,20 +106,21 @@ def test__fetch_package_not_found(bucket):
 
     items = [b"1", b"2", b"3", b"4", b"5"]
 
-    async def iter():
-        class Rec:
+    async def _iter():
+        class _Rec:  # pylint: disable=too-few-public-methods
             def __init__(self, data):
                 self.data = data
 
             async def read_all(self):
+                """read all data"""
                 return self.data
 
         for item in items:
-            yield Rec(item)
+            yield _Rec(item)
 
-    bucket.query.return_value = iter()
+    bucket.query.return_value = _iter()
 
     client = ReductStoreClient("http://localhost:8383", "password")
-    assert [blob for blob in client.walk("topic", 0, 1)] == items
+    assert list(client.walk("topic", 0, 1)) == items
 
     bucket.query.assert_called_with("topic", 0, 1000_000, ttl=60)


### PR DESCRIPTION
**Closes** #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Feature

### What is the current behavior?

ReductStore supports querying records by time and iterate it, this feature wasn't used. 

### What is the new behavior?

I've added the `Client.walk` method which can iterate records and access it in ReductStore without asking timestamps in InfluxDB.

### Does this PR introduce a breaking change?

No

### Other information:
