### PR TITLE
Add support for labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Support for labels, [PR-34](https://github.com/panda-official/DriftPythonClient/pull/34)
+
 ## 0.6.0 - 2023-06-16
 
 ### Added:

--- a/pkg/drift_client/drift_data_package.py
+++ b/pkg/drift_client/drift_data_package.py
@@ -1,5 +1,5 @@
 """Wrapper around DriftPackage"""
-from typing import Optional
+from typing import Optional, Dict
 
 from wavelet_buffer import WaveletBuffer  # pylint: disable=no-name-in-module
 from drift_protocol.common import DataPayload, DriftPackage, StatusCode
@@ -130,3 +130,12 @@ class DriftDataPackage:  # pylint: disable=no-member
             Data payload as NumPy Array
         """
         return self.as_buffer().compose(scale_factor)
+
+    @property
+    def labels(self) -> Dict[str, str]:
+        """Labels as dict"""
+        labels = {}
+        for label in self._pkg.labels:
+            labels[label.key] = label.value
+
+        return labels

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = ["setuptools>=40.8.0", "wheel"]
 [project]
 
 name = "drift-python-client"
-version = "0.6.0"
+version = "0.7.0"
 description = "Python Client to access data of PANDA|Drift"
 requires-python = ">=3.8"
 readme = "README.md"
@@ -31,7 +31,7 @@ classifiers = [
 dependencies = [
     "influxdb-client>=1.36.1, <2.0.0",
     "drift-protocol>=0.5.0, <1.0.0",
-    "wavelet-buffer >= 0.6.0, <1.0.0",
+    "wavelet-buffer >= 0.7.0, <1.0.0",
     "paho-mqtt >= 1.6.1, <2.0.0",
     "numpy >= 1.24.3, < 2.0.0",
     "deprecation==2.1.0",

--- a/tests/package_test.py
+++ b/tests/package_test.py
@@ -80,7 +80,7 @@ def test__scale_factor(good_package, signal):
     assert len(pkg.as_np(scale_factor=1)) == int(len(signal) / 2)
 
 
-def test__labels(good_package, signal):
+def test__labels(good_package):
     """Should provide access to labels"""
     pkg = DriftDataPackage(good_package.SerializeToString())
     assert pkg.labels == {"key": "value"}

--- a/tests/package_test.py
+++ b/tests/package_test.py
@@ -47,6 +47,13 @@ def _make_good_package(buffer: WaveletBuffer) -> DriftPackage:
     any_msg.Pack(payload)
 
     pkg.data.append(any_msg)
+
+    label = DriftPackage.Label()
+    label.key = "key"
+    label.value = "value"
+
+    pkg.labels.append(label)
+
     return pkg
 
 
@@ -71,3 +78,9 @@ def test__scale_factor(good_package, signal):
     """Should return scaled data"""
     pkg = DriftDataPackage(good_package.SerializeToString())
     assert len(pkg.as_np(scale_factor=1)) == int(len(signal) / 2)
+
+
+def test__labels(good_package, signal):
+    """Should provide access to labels"""
+    pkg = DriftDataPackage(good_package.SerializeToString())
+    assert pkg.labels == {"key": "value"}


### PR DESCRIPTION
**Closes** #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Feature

### What is the current behavior?

The Drift Protocol and many services provide labels for packages. However, the library doesn't have an easy way to get them.

### What is the new behavior?

I've added `labels` accessor to DrfitDataPackage.

### Does this PR introduce a breaking change?

No

### Other information:
