### PR TITLE
Add support for Typed Data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Support for Typed Data, [PR-35](https://github.com/panda-official/DriftPythonClient/pull/35)
+
 ## 0.7.0 - 2023-07-11
 
 ### Added

--- a/pkg/drift_client/drift_data_package.py
+++ b/pkg/drift_client/drift_data_package.py
@@ -125,6 +125,7 @@ class DriftDataPackage:  # pylint: disable=no-member
 
     @check_status
     def as_typed_data(self) -> Dict[str, Optional[Variant.SUPPORTED_TYPES]]:
+        """Data payload as typed data"""
         if self.meta.type != MetaInfo.TYPED_DATA:
             raise ValueError("Only typed data supported")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,12 +30,13 @@ classifiers = [
 
 dependencies = [
     "influxdb-client>=1.36.1, <2.0.0",
-    "drift-protocol>=0.5.0, <1.0.0",
+    "drift-protocol>=0.6.0, <1.0.0",
     "wavelet-buffer >= 0.7.0, <1.0.0",
+    "drift-bytes >= 0.2.0, <1.0.0",
     "paho-mqtt >= 1.6.1, <2.0.0",
     "numpy >= 1.24.3, < 2.0.0",
     "deprecation==2.1.0",
-    "reduct-py >= 1.5, <2.0.0",
+    "reduct-py >= 1.6, <2.0.0",
     "minio==7.1.10"
 ]
 

--- a/tests/package_test.py
+++ b/tests/package_test.py
@@ -1,7 +1,11 @@
 """Tests for Package"""
+from typing import Dict
+
 # pylint: disable=no-member
 import numpy as np
 import pytest
+from drift_bytes import Variant, OutputBuffer
+from drift_protocol.meta import TypedDataInfo, MetaInfo
 from wavelet_buffer import (  # pylint: disable=no-name-in-module
     WaveletBuffer,
     WaveletType,
@@ -39,8 +43,6 @@ def _make_good_package(buffer: WaveletBuffer) -> DriftPackage:
     pkg.publish_timestamp.FromMilliseconds(2000)
 
     payload = DataPayload()
-    payload.shape.append(1)
-    payload.shape.append(buffer.parameters.signal_shape[0])
     payload.data = buffer.serialize()
 
     any_msg = Any()
@@ -53,6 +55,48 @@ def _make_good_package(buffer: WaveletBuffer) -> DriftPackage:
     label.value = "value"
 
     pkg.labels.append(label)
+
+    return pkg
+
+
+@pytest.fixture(name="typed_data")
+def _make_typed_data() -> Dict[str, Variant.SUPPORTED_TYPES]:
+    return {"bool": True, "int": 1, "float": 1.0, "string": "string", "none": None}
+
+
+@pytest.fixture(name="typed_data_package")
+def _make_typed_data_package(
+    typed_data: Dict[str, Variant.SUPPORTED_TYPES]
+) -> DriftPackage:
+    pkg = DriftPackage()
+    pkg.id = 1
+    pkg.status = StatusCode.GOOD
+    pkg.source_timestamp.FromMilliseconds(1000)
+    pkg.publish_timestamp.FromMilliseconds(2000)
+
+    buffer = OutputBuffer()
+    items = TypedDataInfo()
+    for key, value in typed_data.items():
+        item = TypedDataInfo.Item()
+        item.name = key
+        if value is None:
+            item.status = StatusCode.BAD
+            buffer.push(Variant(False))
+        else:
+            item.status = StatusCode.GOOD
+            buffer.push(Variant(value))
+        items.items.append(item)
+
+    pkg.meta.type = MetaInfo.TYPED_DATA
+    pkg.meta.typed_data_info.CopyFrom(items)
+
+    payload = DataPayload()
+    payload.data = buffer.bytes()
+
+    any_msg = Any()
+    any_msg.Pack(payload)
+
+    pkg.data.append(any_msg)
 
     return pkg
 
@@ -84,3 +128,9 @@ def test__labels(good_package):
     """Should provide access to labels"""
     pkg = DriftDataPackage(good_package.SerializeToString())
     assert pkg.labels == {"key": "value"}
+
+
+def test__typed_data(typed_data_package, typed_data):
+    """Should provide access to typed data"""
+    pkg = DriftDataPackage(typed_data_package.SerializeToString())
+    assert pkg.as_typed_data() == typed_data

--- a/tests/package_test.py
+++ b/tests/package_test.py
@@ -4,17 +4,17 @@ from typing import Dict
 # pylint: disable=no-member
 import numpy as np
 import pytest
+from google.protobuf.any_pb2 import Any  # pylint: disable=no-name-in-module)
+
 from drift_bytes import Variant, OutputBuffer
 from drift_protocol.meta import TypedDataInfo, MetaInfo
+from drift_protocol.common import DriftPackage, StatusCode, DataPayload
+from drift_client import DriftDataPackage
 from wavelet_buffer import (  # pylint: disable=no-name-in-module
     WaveletBuffer,
     WaveletType,
     denoise,
 )
-from drift_protocol.common import DriftPackage, StatusCode, DataPayload
-from google.protobuf.any_pb2 import Any  # pylint: disable=no-name-in-module)
-
-from drift_client import DriftDataPackage
 
 
 @pytest.fixture(name="signal")


### PR DESCRIPTION
**Closes** #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Feature

### What is the current behavior?

We introduced TypedData to send non-float data and arrays efficiently. We need the support in the client.

### What is the new behavior?

I've implemented the DriftDataPackage.as_typed_data() method to get variables as a dictionary.

### Does this PR introduce a breaking change?

No

### Other information:
