### PR TITLE
Fix Drift Package parsing for images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Only time series data supported, [PR-36](https://github.com/panda-official/DriftPythonClient/pull/36)
+
 ## 0.8.0 - 2023-09-14
 
 ### Added

--- a/pkg/drift_client/drift_data_package.py
+++ b/pkg/drift_client/drift_data_package.py
@@ -118,9 +118,6 @@ class DriftDataPackage:  # pylint: disable=no-member
         Returns:
             Data payload as Wavelet Buffer
         """
-        if self.meta.type != MetaInfo.TIME_SERIES:
-            raise ValueError("Only time series data supported")
-
         return WaveletBuffer.parse(self.as_raw())
 
     @check_status


### PR DESCRIPTION
**Closes** #

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Bug fix

### What is the current behavior?

DriftDataPackage.as_buffer throws an error if package is not time series. However, we use it for images
### What is the new behavior?

I've removed the check.

### Does this PR introduce a breaking change?

No

### Other information:
