### PR TITLE
Add TTL option to DriftClient.walk method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Added
+
+- TTL option to `DriftClient.walk` method, [PR-38](https://github.com/panda-official/DriftPythonClient/pull/38)
+
 ### Fixed
 
-- Error handling in DriftClient.walk, [PR-37](https://github.com/panda-official/DriftPythonClient/pull/37)
+- Error handling in `DriftClient.walk`, [PR-37](https://github.com/panda-official/DriftPythonClient/pull/37)
 
 ## 0.8.1 - 2023-09-14
 

--- a/pkg/drift_client/drift_client.py
+++ b/pkg/drift_client/drift_client.py
@@ -218,6 +218,7 @@ class DriftClient:
         topic: str,
         start: Union[float, datetime, str],
         stop: Union[float, datetime, str],
+        **kwargs,
     ) -> Iterator[DriftDataPackage]:
         """Walks through history data for selected topic
 
@@ -227,7 +228,8 @@ class DriftClient:
                 Format: ISO string, datetime or float timestamp
             stop: End of request timeframe,
                 Format: ISO string, datetime or float timestamp
-
+        KwArgs:
+            ttl: Time to live for the query only for ReductStore
         Returns:
             Iterator with DriftDataPackage
         Raises:
@@ -247,7 +249,7 @@ class DriftClient:
         else:
             start = _convert_type(start)
             stop = _convert_type(stop)
-            for package in self._blob_storage.walk(topic, start, stop):
+            for package in self._blob_storage.walk(topic, start, stop, **kwargs):
                 yield DriftDataPackage(package)
 
     def subscribe_data(self, topic: str, handler: Callable[[DriftDataPackage], None]):

--- a/pkg/drift_client/reduct_client.py
+++ b/pkg/drift_client/reduct_client.py
@@ -70,20 +70,23 @@ class ReductStoreClient:
         except ReductError as err:
             raise DriftClientError(f"Could not read item at {path}") from err
 
-    def walk(self, entry: str, start: int, stop: int) -> Iterator[bytes]:
+    def walk(self, entry: str, start: int, stop: int, **kwargs) -> Iterator[bytes]:
         """
         Walk through the records of an entry between start and stop.
         Args:
             entry: entry name
             start: start timestamp UNIX in seconds
             stop: stop timestamp UNIX in seconds
+        Keyword Args:
+            ttl: time to live for the query
         Raises:
             DriftClientError: if failed to fetch data
         """
 
         bucket: Bucket = self._run(self._client.get_bucket(self._bucket))
 
-        ait = bucket.query(entry, start * 1000_000, stop * 1000_000, ttl=60)
+        ttl = kwargs.get("ttl", 60)
+        ait = bucket.query(entry, start * 1000_000, stop * 1000_000, ttl=ttl)
 
         async def get_next():
             try:

--- a/tests/reduct_client_test.py
+++ b/tests/reduct_client_test.py
@@ -52,11 +52,11 @@ def test__check_server_available():
 
 @pytest.fixture(name="drift_client")
 def _make_drift_client(reduct_client):
+    _ = reduct_client
     return ReductStoreClient("http://localhost:8383", "password")
 
 
-@pytest.mark.usefixtures("reduct_client")
-def test__check_packages_names_available(bucket):
+def test__check_packages_names_available(bucket, drift_client):
     """should check if server is available"""
     bucket.get_entry_list.return_value = [
         EntryInfo(
@@ -69,11 +69,10 @@ def test__check_packages_names_available(bucket):
         )
     ]
 
-    client = ReductStoreClient("http://localhost:8383", "password")
-    assert client.check_package_list(
+    assert drift_client.check_package_list(
         ["topic/1.dp", "topic/2.dp", "topic/3.dp", "topic/4.dp"]
     ) == ["topic/2.dp", "topic/3.dp"]
-    assert client.check_package_list(["unknown/3.dp", "unknown/4.dp"]) == []
+    assert drift_client.check_package_list(["unknown/3.dp", "unknown/4.dp"]) == []
 
 
 def test__fetch_package(mocker, bucket, drift_client):

--- a/tests/reduct_client_test.py
+++ b/tests/reduct_client_test.py
@@ -128,7 +128,7 @@ def test__walk_records(bucket, drift_client):
     bucket.query.assert_called_with("topic", 0, 1000_000, ttl=60)
 
 
-def test___walk_with_error(bucket, drift_client):
+def test__walk_with_error(bucket, drift_client):
     """should raise error if failed to walk records"""
 
     async def _iter():
@@ -140,7 +140,7 @@ def test___walk_with_error(bucket, drift_client):
         list(drift_client.walk("topic", 0, 1))
 
 
-def test___walk_with_ttl(bucket, drift_client):
+def test__walk_with_ttl(bucket, drift_client):
     """should walk records with ttl"""
 
     async def _iter():


### PR DESCRIPTION
**Closes** #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Feature

### What is the current behavior?

The TTL of the data query is hand coded as 60 seconds. Sometimes it is too little. A user should be able to change it.

### What is the new behavior?

I've add the option to `DriftClient.walk` as an optional parameter.

### Does this PR introduce a breaking change?

No

### Other information:
